### PR TITLE
Add 'platform: linux/amd64' to airflow docker-compose.yaml for mac compability

### DIFF
--- a/airflow/Dockerfile
+++ b/airflow/Dockerfile
@@ -4,6 +4,6 @@ ARG CURRENT_USER=$USER
 
 USER root
 # Install Python dependencies to be able to process the wheels from the private PyPI server.
-RUN apt-get -y update && apt-get -y upgrade
+RUN apt-get -y update && ACCEPT_EULA=Y apt-get -y upgrade
 RUN apt-get install -y python3.9-distutils python3.9-dev build-essential
 USER ${CURRENT_USER}

--- a/airflow/docker-compose.yaml
+++ b/airflow/docker-compose.yaml
@@ -91,6 +91,7 @@ x-airflow-common:
 services:
   postgres:
     image: postgres:13
+    platform: linux/amd64
     environment:
       POSTGRES_USER: airflow
       POSTGRES_PASSWORD: airflow
@@ -301,6 +302,7 @@ services:
 
   my-private-pypi:
     image: pypiserver/pypiserver:v1.5.2
+    platform: linux/amd64
     restart: always
     ports:
       - "80:8080"


### PR DESCRIPTION
Hi there,  

I am on an Apple Silicon M2 and an  error occurs with: ‘docker compose --env-file .env up --build -d’. 

Fixed it by adding ‘platform: linux/amd64’ in docker-compose.yaml under  ‘services: postgres:’ and ‘my-private-pypi:’

Hope this is helpful